### PR TITLE
to make it easier to audit what we're...

### DIFF
--- a/dotnet/pom.xml
+++ b/dotnet/pom.xml
@@ -11,9 +11,6 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Language Servers and Dependencies :: .NET</name>
-    <properties>
-        <DOTNET_LS_VERSION>1.32.6</DOTNET_LS_VERSION>
-    </properties>
     <build>
         <plugins>
             <plugin>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -73,7 +73,7 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${basedir}/target" />
-                                <exec dir="${basedir}" executable="docker" failonerror="true">
+                                <exec dir="${basedir}" executable="docker" failonerror="true" resolveexecutable="true">
                                     <arg line="run -v ${basedir}/target:/node_modules node:8.12-alpine sh -c 'npm install --prefix /node_modules typescript@${TYPERSCRIPT_VERSION} typescript-language-server@${TYPESCRIPT_LS_VERSION}; chmod -R 777 /node_modules'" />
                                 </exec>
                                 &gt;

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -24,10 +24,6 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Language Servers and Dependencies :: NodeJS</name>
-    <properties>
-        <TYPERSCRIPT_VERSION>2.8.4</TYPERSCRIPT_VERSION>
-        <TYPESCRIPT_LS_VERSION>0.1.12</TYPESCRIPT_LS_VERSION>
-    </properties>
     <build>
         <plugins>
             <plugin>

--- a/php/pom.xml
+++ b/php/pom.xml
@@ -49,7 +49,7 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${basedir}/target/php-ls" />
-                                <exec dir="${basedir}" executable="docker" failonerror="true">
+                                <exec dir="${basedir}" executable="docker" failonerror="true" resolveexecutable="true">
                                     <arg line="run -v ${basedir}/target/php-ls:/php webdevops/php-apache-dev:alpine-php7 sh -c 'cd /php; composer require jetbrains/phpstorm-stubs:dev-master; composer require felixfbecker/language-server:${PHP_LS_VERSION}; composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs; mv  vendor/* .; rm -rf vendor; cp /usr/local/bin/composer /php/composer; chmod -R 777 /php'" />
                                 </exec>
                                 <mkdir dir="${basedir}/target/zend-debugger"/>

--- a/php/pom.xml
+++ b/php/pom.xml
@@ -55,7 +55,7 @@
                                 <mkdir dir="${basedir}/target/zend-debugger"/>
                                 <!-- download Debugger.so from Zend repo -->
                                 <echo message="Downloading ZendDebugger.so ..." />
-                                <get src="http://downloads.zend.com/studio_debugger/${ZEND_DEBUGGER_VERSION}.zip"
+                                <get src="http://downloads.zend.com/studio_debugger/${PHP_ZEND_DEBUGGER_VERSION}.zip"
                                 dest="${basedir}/target/zend-debugger/ZendDebugger.zip"
                                 verbose="false"
                                 usetimestamp="true"/>

--- a/php/pom.xml
+++ b/php/pom.xml
@@ -13,9 +13,6 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Language Servers and Dependencies :: PHP</name>
-    <properties>
-    <PHP_LS_VERSION>5.4.2</PHP_LS_VERSION>
-    </properties>
     <build>
         <plugins>
             <plugin>
@@ -58,12 +55,12 @@
                                 <mkdir dir="${basedir}/target/zend-debugger"/>
                                 <!-- download Debugger.so from Zend repo -->
                                 <echo message="Downloading ZendDebugger.so ..." />
-                                <get src="http://downloads.zend.com/studio_debugger/2018_10_02/ZendDebugger-rpm-x86_64-php-71-php-72.zip"
-                                dest="${basedir}/target/zend-debugger"
+                                <get src="http://downloads.zend.com/studio_debugger/${ZEND_DEBUGGER_VERSION}.zip"
+                                dest="${basedir}/target/zend-debugger/ZendDebugger.zip"
                                 verbose="false"
                                 usetimestamp="true"/>
                                 <echo message="Unzipping Zend archive..." />
-                                <unzip src="${basedir}/target/zend-debugger/ZendDebugger-rpm-x86_64-php-71-php-72.zip" dest="${basedir}/target/zend-debugger" />
+                                <unzip src="${basedir}/target/zend-debugger/ZendDebugger.zip" dest="${basedir}/target/zend-debugger" />
                                 <copy file="${basedir}/target/zend-debugger/php-7.1.x/ZendDebugger.so" tofile="${basedir}/target/php-ls/ZendDebugger.so"/>
                                 <delete dir="${basedir}/target/zend-debugger"/>
                             </target>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,30 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Language Servers and Dependencies :: Root</name>
+
+    <!-- to make it easier to audit what we're including in downstream builds, put all the dependency info in a single file -->
+    <properties>
+
+        <!-- wget https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v${DOTNET_LS_VERSION}/omnisharp-linux-x64.tar.gz -->
+        <DOTNET_LS_VERSION>1.32.6</DOTNET_LS_VERSION>
+
+        <!-- npm install typescript@${TYPERSCRIPT_VERSION} typescript-language-server@${TYPESCRIPT_LS_VERSION} -->
+        <TYPERSCRIPT_VERSION>2.8.4</TYPERSCRIPT_VERSION>
+        <TYPESCRIPT_LS_VERSION>0.1.12</TYPESCRIPT_LS_VERSION>
+
+        <!-- composer require jetbrains/phpstorm-stubs:dev-master; 
+             composer require felixfbecker/language-server:${PHP_LS_VERSION}; 
+             composer run-script \-\-working-dir=vendor/felixfbecker/language-server parse-stubs 
+         -->
+        <PHP_LS_VERSION>5.4.2</PHP_LS_VERSION>
+        <!-- wget http://downloads.zend.com/studio_debugger/${ZEND_DEBUGGER_VERSION}.zip -->
+        <ZEND_DEBUGGER_VERSION>2018_10_02/ZendDebugger-rpm-x86_64-php-71-php-72</ZEND_DEBUGGER_VERSION>
+
+        <!-- pip install python-language-server[all]==${PYTHON_LS_VERSION} -->
+        <PYTHON_LS_VERSION>0.18.0</PYTHON_LS_VERSION>
+
+    </properties>
+
     <modules>
         <module>node</module>
         <module>php</module>

--- a/pom.xml
+++ b/pom.xml
@@ -21,29 +21,6 @@
     <packaging>pom</packaging>
     <name>Language Servers and Dependencies :: Root</name>
 
-    <!-- to make it easier to audit what we're including in downstream builds, put all the dependency info in a single file -->
-    <properties>
-
-        <!-- wget https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v${DOTNET_LS_VERSION}/omnisharp-linux-x64.tar.gz -->
-        <DOTNET_LS_VERSION>1.32.6</DOTNET_LS_VERSION>
-
-        <!-- npm install typescript@${TYPERSCRIPT_VERSION} typescript-language-server@${TYPESCRIPT_LS_VERSION} -->
-        <TYPERSCRIPT_VERSION>2.8.4</TYPERSCRIPT_VERSION>
-        <TYPESCRIPT_LS_VERSION>0.1.12</TYPESCRIPT_LS_VERSION>
-
-        <!-- composer require jetbrains/phpstorm-stubs:dev-master; 
-             composer require felixfbecker/language-server:${PHP_LS_VERSION}; 
-             composer run-script \-\-working-dir=vendor/felixfbecker/language-server parse-stubs 
-         -->
-        <PHP_LS_VERSION>5.4.2</PHP_LS_VERSION>
-        <!-- wget http://downloads.zend.com/studio_debugger/${ZEND_DEBUGGER_VERSION}.zip -->
-        <ZEND_DEBUGGER_VERSION>2018_10_02/ZendDebugger-rpm-x86_64-php-71-php-72</ZEND_DEBUGGER_VERSION>
-
-        <!-- pip install python-language-server[all]==${PYTHON_LS_VERSION} -->
-        <PYTHON_LS_VERSION>0.18.0</PYTHON_LS_VERSION>
-
-    </properties>
-
     <modules>
         <module>node</module>
         <module>php</module>
@@ -56,6 +33,30 @@
         <tag>HEAD</tag>
         <url>https://github.com/che-samples/ls-dependencies</url>
     </scm>
+
+    <!-- to make it easier to audit what we're including in downstream builds, put all the dependency info in a single file -->
+    <properties>
+
+        <!-- wget https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v${DOTNET_LS_VERSION}/omnisharp-linux-x64.tar.gz -->
+        <DOTNET_LS_VERSION>1.32.6</DOTNET_LS_VERSION>
+
+        <!-- composer require jetbrains/phpstorm-stubs:dev-master; 
+             composer require felixfbecker/language-server:${PHP_LS_VERSION}; 
+             composer run-script \-\-working-dir=vendor/felixfbecker/language-server parse-stubs 
+         -->
+        <PHP_LS_VERSION>5.4.2</PHP_LS_VERSION>
+        <!-- wget http://downloads.zend.com/studio_debugger/${ZEND_DEBUGGER_VERSION}.zip -->
+        <PHP_ZEND_DEBUGGER_VERSION>2018_10_02/ZendDebugger-rpm-x86_64-php-71-php-72</PHP_ZEND_DEBUGGER_VERSION>
+
+        <!-- pip install python-language-server[all]==${PYTHON_LS_VERSION} -->
+        <PYTHON_LS_VERSION>0.18.0</PYTHON_LS_VERSION>
+
+        <!-- npm install typescript@${TYPERSCRIPT_VERSION} typescript-language-server@${TYPESCRIPT_LS_VERSION} -->
+        <TYPERSCRIPT_VERSION>2.8.4</TYPERSCRIPT_VERSION>
+        <TYPESCRIPT_LS_VERSION>0.1.12</TYPESCRIPT_LS_VERSION>
+
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -50,7 +50,7 @@
                             <target>
                                 <mkdir dir="${basedir}/target/python-ls" />
                                 <echo message="Running pip install to download pyls and its deps..." />
-                                <exec dir="${basedir}" executable="docker" failonerror="true">
+                                <exec dir="${basedir}" executable="docker" failonerror="true" resolveexecutable="true">
                                     <arg line="run -v ${basedir}/target/python-ls:/python -u root registry.access.redhat.com/rhscl/python-36-rhel7:1-30 sh -c 'pip install python-language-server[all]==${PYTHON_LS_VERSION} --install-option='--prefix=/python'; chmod -R 777 /python'" />
                                 </exec>
                             </target>

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -13,9 +13,6 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Language Servers and Dependencies :: Python</name>
-    <properties>
-        <PYTHON_LS_VERSION>0.18.0</PYTHON_LS_VERSION>
-    </properties>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
to make it easier to audit what we're including in downstream builds, put all the dependency info in a single file

Change-Id: I89a1a9353fa468918e175cbc65ba40fe50f05747
Signed-off-by: nickboldt <nboldt@redhat.com>