### PR TITLE
CRW-2 should we be using the latest root pom...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>6.12.0</version>
+        <version>6.16.0-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.ls.dependencies</groupId>
     <artifactId>language-servers-dependencies</artifactId>


### PR DESCRIPTION
CRW-2 should we be using the latest root pom / depmgmt pom?

Change-Id: I266b08ccc35d9793826d5ca12e935767e35246d6
Signed-off-by: nickboldt <nboldt@redhat.com>